### PR TITLE
Pointing To New Contract

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "BluefinSpot"
 version = "1.0.0"
-published-at = "0x3492c874c1e3b3e2984e8c41b589e642d4d0a5d6459e5a9cfc2d52fd7c89c267"
+published-at = "0xb104ecc75397f3a65735ef26c85a037da1d197e26f4f275a9990a577ba0e6c4c"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "mainnet-v1.35.2", override=true }


### PR DESCRIPTION
Updated `published_at` filed in Move.toml to start pointing to the latest bluefin spot contract.